### PR TITLE
json/reader: rename to CJsonReader

### DIFF
--- a/src/c-json.h
+++ b/src/c-json.h
@@ -7,7 +7,8 @@ extern "C" {
 #include <stdarg.h>
 #include <stdbool.h>
 
-typedef struct CJson CJson;
+typedef struct CJsonReader CJsonReader;
+typedef struct CJsonWriter CJsonWriter;
 typedef struct CJsonLevel CJsonLevel;
 
 enum  {
@@ -26,25 +27,26 @@ enum {
         C_JSON_TYPE_OBJECT,
 };
 
-int c_json_new(CJson **jsonp, size_t max_depth);
-CJson * c_json_free(CJson *json);
+/* readers */
+int c_json_reader_new(CJsonReader **readerp, size_t max_depth);
+CJsonReader * c_json_reader_free(CJsonReader *reader);
 
-void c_json_begin_read(CJson *json, const char *string);
-int c_json_end_read(CJson *json);
-int c_json_peek(CJson *json);
-int c_json_read_null(CJson *json);
-int c_json_read_string(CJson *json, char **stringp);
-int c_json_read_number(CJson *json, const char **numberp, size_t *n_numberp);
-int c_json_read_bool(CJson *json, bool *boolp);
-bool c_json_more(CJson *json);
-int c_json_enter_array(CJson *json);
-int c_json_exit_array(CJson *json);
-int c_json_enter_object(CJson *json);
-int c_json_exit_object(CJson *json);
+void c_json_reader_begin_read(CJsonReader *reader, const char *string);
+int c_json_reader_end_read(CJsonReader *reader);
+int c_json_reader_peek(CJsonReader *reader);
+int c_json_reader_read_null(CJsonReader *reader);
+int c_json_reader_read_string(CJsonReader *reader, char **stringp);
+int c_json_reader_read_number(CJsonReader *reader, const char **numberp, size_t *n_numberp);
+int c_json_reader_read_bool(CJsonReader *reader, bool *boolp);
+bool c_json_reader_more(CJsonReader *reader);
+int c_json_reader_enter_array(CJsonReader *reader);
+int c_json_reader_exit_array(CJsonReader *reader);
+int c_json_reader_enter_object(CJsonReader *reader);
+int c_json_reader_exit_object(CJsonReader *reader);
 
-static inline void c_json_freep(CJson **jsonp) {
-        if (*jsonp)
-                c_json_free(*jsonp);
+static inline void c_json_reader_freep(CJsonReader **readerp) {
+        if (*readerp)
+                c_json_reader_free(*readerp);
 }
 
 #ifdef __cplusplus

--- a/src/json-validate.c
+++ b/src/json-validate.c
@@ -35,37 +35,37 @@ int read_file(FILE *file, char **contentsp) {
         return 0;
 }
 
-int json_read_value(CJson *json) {
-        switch (c_json_peek(json)) {
+int json_read_value(CJsonReader *reader) {
+        switch (c_json_reader_peek(reader)) {
                 case C_JSON_TYPE_NULL:
-                        return c_json_read_null(json);
+                        return c_json_reader_read_null(reader);
 
                 case C_JSON_TYPE_BOOLEAN:
-                        return c_json_read_bool(json, NULL);
+                        return c_json_reader_read_bool(reader, NULL);
 
                 case C_JSON_TYPE_STRING:
-                        return c_json_read_string(json, NULL);
+                        return c_json_reader_read_string(reader, NULL);
 
                 case C_JSON_TYPE_NUMBER:
-                        return c_json_read_number(json, NULL, NULL);
+                        return c_json_reader_read_number(reader, NULL, NULL);
 
                 case C_JSON_TYPE_ARRAY:
-                        c_json_enter_array(json);
-                        while (c_json_more(json)) {
-                                int r = json_read_value(json);
+                        c_json_reader_enter_array(reader);
+                        while (c_json_reader_more(reader)) {
+                                int r = json_read_value(reader);
                                 if (r)
                                         return r;
                         }
-                        return c_json_exit_array(json);
+                        return c_json_reader_exit_array(reader);
 
                 case C_JSON_TYPE_OBJECT:
-                        c_json_enter_object(json);
-                        while (c_json_more(json)) {
-                                int r = json_read_value(json);
+                        c_json_reader_enter_object(reader);
+                        while (c_json_reader_more(reader)) {
+                                int r = json_read_value(reader);
                                 if (r)
                                         return r;
                         }
-                        return c_json_exit_object(json);
+                        return c_json_reader_exit_object(reader);
 
                 default:
                         return C_JSON_E_INVALID_JSON;
@@ -74,7 +74,7 @@ int json_read_value(CJson *json) {
 
 int main(int argc, char **argv) {
         _c_cleanup_ (c_fclosep) FILE *file = NULL;
-        _c_cleanup_ (c_json_freep) CJson *json = NULL;
+        _c_cleanup_ (c_json_reader_freep) CJsonReader *reader = NULL;
         _c_cleanup_ (c_freep) char *input = NULL;
         int r;
 
@@ -92,11 +92,11 @@ int main(int argc, char **argv) {
                         return 1;
         }
 
-        c_json_new(&json, 256);
-        c_json_begin_read(json, input);
-        r = json_read_value(json);
+        c_json_reader_new(&reader, 256);
+        c_json_reader_begin_read(reader, input);
+        r = json_read_value(reader);
         if (r)
                 return r;
 
-        return c_json_end_read(json);
+        return c_json_reader_end_read(reader);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,7 @@ libcjson_deps = [
 libcjson_private = static_library(
         'cjson-private',
         [
-                'c-json.c',
+                'c-json-reader.c',
         ],
         c_args: [
                 '-fvisibility=hidden',

--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -6,147 +6,147 @@
 #include "c-json.h"
 
 static void test_basic(void) {
-        static CJson *json = NULL;
+        static CJsonReader *reader = NULL;
         _c_cleanup_(c_freep) char *string = NULL;
         const char *number;
         size_t n_number;
         bool b = false;
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "\"foo \\u00e4bc\"");
-        assert(!c_json_read_string(json, &string));
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "\"foo \\u00e4bc\"");
+        assert(!c_json_reader_read_string(reader, &string));
         assert(string && !strcmp(string, "foo äbc"));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "12345678");
-        assert(!c_json_read_number(json, &number, &n_number));
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "12345678");
+        assert(!c_json_reader_read_number(reader, &number, &n_number));
         assert(strcmp(number, "12345678") == 0);
         assert(n_number == strlen("12345678"));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "-1");
-        assert(!c_json_read_number(json, &number, &n_number));
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "-1");
+        assert(!c_json_reader_read_number(reader, &number, &n_number));
         assert(strcmp(number, "-1") == 0);
         assert(n_number == strlen("-1"));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "-3.14");
-        assert(!c_json_read_number(json, &number, &n_number));
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "-3.14");
+        assert(!c_json_reader_read_number(reader, &number, &n_number));
         assert(strcmp(number, "-3.14") == 0);
         assert(n_number == strlen("-3.14"));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "true");
-        assert(!c_json_read_bool(json, &b));
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "true");
+        assert(!c_json_reader_read_bool(reader, &b));
         assert(b == true);
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "null");
-        assert(!c_json_read_null(json));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "null");
+        assert(!c_json_reader_read_null(reader));
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 }
 
 static void test_array(void) {
-        static CJson *json = NULL;
+        static CJsonReader *reader = NULL;
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "[]");
-        assert(!c_json_enter_array(json));
-        assert(!c_json_more(json));
-        assert(!c_json_exit_array(json));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "[]");
+        assert(!c_json_reader_enter_array(reader));
+        assert(!c_json_reader_more(reader));
+        assert(!c_json_reader_exit_array(reader));
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "[ 1, 2, 3, 4, 5, 6 ]");
-        assert(!c_json_enter_array(json));
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "[ 1, 2, 3, 4, 5, 6 ]");
+        assert(!c_json_reader_enter_array(reader));
         for (uint64_t i = 1; i < 7; i += 1) {
                 const char *number;
                 unsigned long long n;
 
-                assert(c_json_more(json));
-                assert(!c_json_read_number(json, &number, NULL));
+                assert(c_json_reader_more(reader));
+                assert(!c_json_reader_read_number(reader, &number, NULL));
                 n = strtoull(number, NULL, 0);
                 assert(n == i);
         }
-        assert(!c_json_exit_array(json));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_exit_array(reader));
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 }
 
 static void test_object(void) {
-        static CJson *json = NULL;
+        static CJsonReader *reader = NULL;
         static struct { const char *key; uint64_t value; } expected[] = {
                 { "foo", 42 },
                 { "bar", 43 }
         };
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "{}");
-        assert(!c_json_enter_object(json));
-        assert(!c_json_more(json));
-        assert(!c_json_exit_object(json));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "{}");
+        assert(!c_json_reader_enter_object(reader));
+        assert(!c_json_reader_more(reader));
+        assert(!c_json_reader_exit_object(reader));
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "{ \"foo\": 42, \"bar\": 43 }");
-        assert(!c_json_enter_object(json));
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "{ \"foo\": 42, \"bar\": 43 }");
+        assert(!c_json_reader_enter_object(reader));
         for (uint64_t i = 0; i < 2; i += 1) {
                 _c_cleanup_(c_freep) char *key = NULL;
                 const char *number;
                 uint64_t n;
 
-                assert(c_json_more(json));
-                assert(!c_json_read_string(json, &key));
+                assert(c_json_reader_more(reader));
+                assert(!c_json_reader_read_string(reader, &key));
                 assert(!strcmp(expected[i].key, key));
-                assert(!c_json_read_number(json, &number, NULL));
+                assert(!c_json_reader_read_number(reader, &number, NULL));
                 n = strtoull(number, NULL, 0);
                 assert(expected[i].value == n);
         }
-        assert(!c_json_exit_object(json));
-        assert(!c_json_end_read(json));
-        json = c_json_free(json);
+        assert(!c_json_reader_exit_object(reader));
+        assert(!c_json_reader_end_read(reader));
+        reader = c_json_reader_free(reader);
 }
 
 static void test_peek(void) {
-        static CJson *json = NULL;
+        static CJsonReader *reader = NULL;
 
-        assert(!c_json_new(&json, 256));
-        c_json_begin_read(json, "{ \"foo\": \"bar\", \"bar\": 42, \"baz\": true }");
+        assert(!c_json_reader_new(&reader, 256));
+        c_json_reader_begin_read(reader, "{ \"foo\": \"bar\", \"bar\": 42, \"baz\": true }");
 
-        assert(c_json_peek(json) == C_JSON_TYPE_OBJECT);
-        assert(!c_json_enter_object(json));
+        assert(c_json_reader_peek(reader) == C_JSON_TYPE_OBJECT);
+        assert(!c_json_reader_enter_object(reader));
 
-        assert(c_json_peek(json) == C_JSON_TYPE_STRING);
-        assert(!c_json_read_string(json, NULL));
-        assert(c_json_peek(json) == C_JSON_TYPE_STRING);
-        assert(!c_json_read_string(json, NULL));
+        assert(c_json_reader_peek(reader) == C_JSON_TYPE_STRING);
+        assert(!c_json_reader_read_string(reader, NULL));
+        assert(c_json_reader_peek(reader) == C_JSON_TYPE_STRING);
+        assert(!c_json_reader_read_string(reader, NULL));
 
-        assert(c_json_peek(json) == C_JSON_TYPE_STRING);
-        assert(!c_json_read_string(json, NULL));
-        assert(c_json_peek(json) == C_JSON_TYPE_NUMBER);
-        assert(!c_json_read_number(json, NULL, NULL));
+        assert(c_json_reader_peek(reader) == C_JSON_TYPE_STRING);
+        assert(!c_json_reader_read_string(reader, NULL));
+        assert(c_json_reader_peek(reader) == C_JSON_TYPE_NUMBER);
+        assert(!c_json_reader_read_number(reader, NULL, NULL));
 
-        assert(c_json_peek(json) == C_JSON_TYPE_STRING);
-        assert(!c_json_read_string(json, NULL));
-        assert(c_json_peek(json) == C_JSON_TYPE_BOOLEAN);
-        assert(!c_json_read_bool(json, NULL));
+        assert(c_json_reader_peek(reader) == C_JSON_TYPE_STRING);
+        assert(!c_json_reader_read_string(reader, NULL));
+        assert(c_json_reader_peek(reader) == C_JSON_TYPE_BOOLEAN);
+        assert(!c_json_reader_read_bool(reader, NULL));
 
-        assert(c_json_peek(json) == -1);
-        assert(!c_json_exit_object(json));
-        json = c_json_free(json);
+        assert(c_json_reader_peek(reader) == -1);
+        assert(!c_json_reader_exit_object(reader));
+        reader = c_json_reader_free(reader);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This will allow us to introduce CJsonWriter as a separate object, as
the reader and writer really are completely distinct.

Signed-off-by: Tom Gundersen <teg@jklm.no>